### PR TITLE
Update spot instalation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,10 +76,11 @@ ProbBBC depends on [Spot](https://spot.lre.epita.fr/) for handling LTL formulas.
 
 ```shell
 ## Download the source code of spot
-wget http://www.lrde.epita.fr/dload/spot/spot-2.11.3.tar.gz
-tar xvf spot-2.11.3.tar.gz 
+wget http://www.lrde.epita.fr/dload/spot/spot-2.11.5.tar.gz
+tar xvf spot-2.11.5.tar.gz
 cd spot-2.11.5
-./configure --prefix "$OLDPWD/.venv/" --with-python_prefix  "$OLDPWD/.venv/" --with-python_exec_prefix  "$OLDPWD/.venv/"
+# Specify appropriate CPU/OS for your environment
+./configure --prefix "$OLDPWD/.venv/" --build=x86_64-unknown-linux-gnu --host=x86_64-unknown-linux-gnu
 # Build and install Spot
 make -j8 && make install
 ```


### PR DESCRIPTION
spotのインストール手順を修正しました。(自分の手元環境である『Ubuntu 22.04.4 LTS』ではこれで動作したのですが、例えばmacなどの別環境だと元のほうが正しい可能性もあるのでなんともいえないところですがどうでしょうか...)