### PR TITLE
WIP: Add integration test on 

### DIFF
--- a/.github/workflows/integration-test-mac.yml
+++ b/.github/workflows/integration-test-mac.yml
@@ -1,0 +1,87 @@
+name: Integration test on macos
+on: [push, pull_request]
+env:
+  PRISM-VERSION: 4.8.1-mac64-arm
+  SPOT-VERSION: 2.12
+  AALPY-VERSION: v.1.4.1
+jobs:
+  test-on-macos:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: check Python3 version
+        run: python3 --version
+
+      - name: Download Prism
+        run: |
+          wget https://www.prismmodelchecker.org/dl/prism-${{ env.PRISM-VERSION }}.tar.gz
+          tar xfz prism-${{ env.PRISM-VERSION }}.tar.gz
+          cd prism-${{ env.PRISM-VERSION }}
+          ./install.sh
+
+      # Building spot takes time, so we cache it.
+      - name: Cache Spot
+        id: cache-spot
+        uses: actions/cache@v4
+        env:
+          cache-name: cache-spot
+        with:
+          path: spot-${{ env.SPOT-VERSION }}
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.SPOT-VERSION }}
+      - if: ${{ steps.cache-spot.outputs.cache-hit != 'true' }}
+        name: Build Spot
+        run: |
+          ## Download the source code of spot
+          wget http://www.lrde.epita.fr/dload/spot/spot-${{ env.SPOT-VERSION }}.tar.gz
+          tar xvf spot-${{ env.SPOT-VERSION }}.tar.gz
+          cd spot-${{ env.SPOT-VERSION }}
+          # Specify appropriate CPU/OS for your environment
+          ./configure --prefix "$OLDPWD/.venv/"
+          # Build Spot
+          make -j8
+
+      - name: Set-up Python venv
+        run: python3 -m venv .venv
+      - name: Install spot
+        run: |
+          cd spot-${{ env.SPOT-VERSION }}
+          make install
+      - name: Check spot installation
+        run: |
+          . .venv/bin/activate
+          python3 -c "import spot"
+      - name: Install AALpy
+        run: |
+          git clone https://github.com/DES-Lab/AALpy -b ${{ env.AALPY-VERSION }} --depth 1
+          . .venv/bin/activate
+          cd AALpy
+          patch -p1 < ../aalpy.patch
+          python3 -m pip install pydot
+          python3 -m pip install setuptools
+          python3 setup.py install
+          echo "XXX: debug: pip list after install aalpy"
+          python3 -m pip list
+      - name: Check AALpy installation
+        run: |
+          . .venv/bin/activate
+          python3 -c "import aalpy"
+      - name: Install other packages
+        run: |
+          . .venv/bin/activate
+          pip install -r requirements.txt
+
+      - name: Run src/main.py as an integration test
+        run: |
+          . .venv/bin/activate
+          python3 src/main.py \
+            --model-file benchmarks/mqtt/mqtt.dot \
+            --prop-file benchmarks/mqtt/mqtt.props \
+            --prism-path "$(pwd)/prism-${{ env.PRISM-VERSION }}/bin/prism" \
+            --output-dir result \
+            --min-rounds 3 \
+            --max-rounds 5 \
+            --save-files-for-each-round \
+            --target-unambiguity 0.99
+

--- a/.github/workflows/integration-test-mac.yml
+++ b/.github/workflows/integration-test-mac.yml
@@ -72,16 +72,16 @@ jobs:
           . .venv/bin/activate
           pip install -r requirements.txt
 
-      - name: Run src/main.py as an integration test
-        run: |
-          . .venv/bin/activate
-          python3 src/main.py \
-            --model-file benchmarks/mqtt/mqtt.dot \
-            --prop-file benchmarks/mqtt/mqtt.props \
-            --prism-path "$(pwd)/prism-${{ env.PRISM-VERSION }}/bin/prism" \
-            --output-dir result \
-            --min-rounds 3 \
-            --max-rounds 5 \
-            --save-files-for-each-round \
-            --target-unambiguity 0.99
+      # - name: Run src/main.py as an integration test
+      #   run: |
+      #     . .venv/bin/activate
+      #     python3 src/main.py \
+      #       --model-file benchmarks/mqtt/mqtt.dot \
+      #       --prop-file benchmarks/mqtt/mqtt.props \
+      #       --prism-path "$(pwd)/prism-${{ env.PRISM-VERSION }}/bin/prism" \
+      #       --output-dir result \
+      #       --min-rounds 3 \
+      #       --max-rounds 5 \
+      #       --save-files-for-each-round \
+      #       --target-unambiguity 0.99
 

--- a/.github/workflows/integration-test-ubuntu.yml
+++ b/.github/workflows/integration-test-ubuntu.yml
@@ -1,0 +1,83 @@
+name: Integration test on ubuntu
+on: [push, pull_request]
+env:
+  PRISM-VERSION: 4.8.1-linux64-x86
+  SPOT-VERSION: 2.12
+  AALPY-VERSION: v.1.4.1
+jobs:
+  test-on-ubuntu:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: check Python3 version
+        run: python3 --version
+
+      - name: Download Prism
+        run: |
+          wget https://www.prismmodelchecker.org/dl/prism-${{ env.PRISM-VERSION }}.tar.gz
+          tar xfz prism-${{ env.PRISM-VERSION }}.tar.gz
+          cd prism-${{ env.PRISM-VERSION }}
+          ./install.sh
+
+      # Building spot takes time, so we cache it.
+      - name: Cache Spot
+        id: cache-spot
+        uses: actions/cache@v4
+        env:
+          cache-name: cache-spot
+        with:
+          path: spot-${{ env.SPOT-VERSION }}
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.SPOT-VERSION }}
+      - if: ${{ steps.cache-spot.outputs.cache-hit != 'true' }}
+        name: Build Spot
+        run: |
+          ## Download the source code of spot
+          wget http://www.lrde.epita.fr/dload/spot/spot-${{ env.SPOT-VERSION }}.tar.gz
+          tar xvf spot-${{ env.SPOT-VERSION }}.tar.gz
+          cd spot-${{ env.SPOT-VERSION }}
+          # Specify appropriate CPU/OS for your environment
+          ./configure --prefix "$OLDPWD/.venv/" --build=x86_64-unknown-linux-gnu --host=x86_64-unknown-linux-gnu
+          # Build Spot
+          make -j8
+
+      - name: Set-up Python venv
+        run: python3 -m venv .venv
+      - name: Install spot
+        run: |
+          cd spot-${{ env.SPOT-VERSION }}
+          make install
+      - name: Check spot installation
+        run: |
+          . .venv/bin/activate
+          python3 -c "import spot"
+      - name: Install AALpy
+        run: |
+          git clone https://github.com/DES-Lab/AALpy -b ${{ env.AALPY-VERSION }} --depth 1
+          . .venv/bin/activate
+          cd AALpy
+          patch -p1 < ../aalpy.patch
+          python3 -m pip install pydot
+          python3 setup.py install
+      - name: Check AALpy installation
+        run: |
+          . .venv/bin/activate
+          python3 -c "import aalpy"
+      - name: Install other packages
+        run: |
+          . .venv/bin/activate
+          pip install -r requirements.txt
+
+      - name: Run src/main.py as an integration test
+        run: |
+          . .venv/bin/activate
+          python3 src/main.py \
+            --model-file benchmarks/mqtt/mqtt.dot \
+            --prop-file benchmarks/mqtt/mqtt.props \
+            --prism-path "$(pwd)/prism-${{ env.PRISM-VERSION }}/bin/prism" \
+            --output-dir result \
+            --min-rounds 3 \
+            --max-rounds 5 \
+            --save-files-for-each-round \
+            --target-unambiguity 0.99

--- a/README.md
+++ b/README.md
@@ -76,9 +76,9 @@ ProbBBC depends on [Spot](https://spot.lre.epita.fr/) for handling LTL formulas.
 
 ```shell
 ## Download the source code of spot
-wget http://www.lrde.epita.fr/dload/spot/spot-2.11.5.tar.gz
-tar xvf spot-2.11.5.tar.gz
-cd spot-2.11.5
+wget http://www.lrde.epita.fr/dload/spot/spot-2.12.tar.gz
+tar xvf spot-2.12.tar.gz
+cd spot-2.12
 # Specify appropriate CPU/OS for your environment
 ./configure --prefix "$OLDPWD/.venv/" --build=x86_64-unknown-linux-gnu --host=x86_64-unknown-linux-gnu
 # Build and install Spot

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-numpy==1.24.2
-pydot==1.4.2
-pyparsing==3.0.9
-scipy==1.10.1
+numpy==2.1.1
+pydot==3.0.1
+pyparsing==3.1.4
+scipy==1.14.1
 ruff==0.6.3

--- a/src/Smc.py
+++ b/src/Smc.py
@@ -101,7 +101,9 @@ class StatisticalModelChecker:
 
     def reset_sut(self):
         self.number_of_steps = 0
-        self.current_output = self.sut.pre()
+        # XXX: Temporary fix for integration test. Need to be checked.
+        self.sut.pre()
+        self.current_output = self.sut.step(None)
         self.current_output_aps = self.current_output.split("__")
         self.strategy_bridge.reset()
         self.exec_trace = []


### PR DESCRIPTION
# このPRは途中です。テスト通ってるように見えますがまだ壊れている(キャッシュのために通している)のでマージしないでください

Mac用のintegration testのPRの途中です。 https://github.com/SoftwareFoundationGroupAtKyotoU/probBBC/pull/4 の上に作っています。

- AALpyのインストール時になぜか `ModuleNotFoundError: No module named 'setuptools'` で落ちるので`pip install setuptools`しています。(Ubuntuのときは不要でした)
  - AALpyインストール後に `pip list` するとなぜかaalpyが**3つ**インストールされています(なぜ...?)
```
Package    Version
---------- -------
aalpy      1.4.1
aalpy      1.4.1
aalpy      1.4.1
pip        24.2
pydot      3.0.1
pyparsing  3.1.4
setuptools 74.1.2
```
- numpy等のバージョンが古くて`pip install`に失敗したので`requirements.txt`記載のバージョンを今`pip install`で自動的に入るものに上げました。

### エラーについて
- 現状のintegration testは`python3 src/main.py ...`時に以下のエラーで落ちます。
```
2024-09-14 16:46:34,772 ProbBlackBoxChecking[357] [INFO]: Hypothesis probability : 0.8634914523055469
2024-09-14 16:46:34,798 ProbBlackBoxChecking[377] [INFO]: SMC executed SUL 4 steps (0 queries)
2024-09-14 16:46:34,799 ProbBlackBoxChecking[381] [INFO]: CEX from SMC: ['ConnectC1WithWill', 'c2_ConnectionClosed_client_close__c1_ConnAck', 'ConnectC2', 'c2_ConnAck__c1_Empty', 'SubscribeC2', 'c2_Pub_c2_my_topic_bye__c2_SubAck__c1_Empty', 'ConnectC1WithWill', 'c2_Pub_c2_my_topic_bye__c1_ConnectionClosed_eof_stream']
libc++abi: terminating due to uncaught exception of type swig::stop_iteration
/Users/runner/work/_temp/dbce6360-a26b-46c3-bd1c-ece73ab31e0e.sh: line 10: 44973 Abort trap: 6           python3 src/main.py --model-file benchmarks/mqtt/mqtt.dot --prop-file benchmarks/mqtt/mqtt.props --prism-path "$(pwd)/prism-4.8.1-mac64-arm/bin/prism" --output-dir result --min-rounds 3 --max-rounds 5 --save-files-for-each-round --target-unambiguity 0.99
Error: Process completed with exit code 134.
```
- 実際のCIでエラー落ちする様子: https://github.com/satos---jp/probBBC/actions/runs/10863965904/job/30148712010
- どうやらデバッグした感じ https://github.com/satos---jp/probBBC/blob/683bd6046a4e52d571913ceab751e6917d472a84/src/Smc.py#L140 で落ちているようで、試しに https://github.com/satos---jp/probBBC/commit/5e693710bb6f50aa5cf67d1fb3fb18ef8d2b6f43#diff-7718067438b179db573ada727ee9ee1c01a839b76168f0c382ded307d73b1e9aR163-R166 をやってみると `for e in edges: pass` の途中で落ちてるみたいです。
  - この`edges`変数はspotライブラリから提供されるPythonでラップされたなんらかのC++構造体ぽくて、spotのバグであるかどうかは調査の必要ありそうです。(temporary fixのやつが何かわるさしている可能性もあると思います)
    - spotのリポジトリは https://gitlab.lre.epita.fr/spot/spot ですが、検索した限り関連issueは見つけられてないです。
  - 詳しく調べるために、まずはもっと小さなバグる例を作る必要があるかと思います。(自分の手元にmacがないのでworkflow上でしかデバッグできずいささか不便ですが...)